### PR TITLE
[#68] boyjRTC 클래스 추가

### DIFF
--- a/app/src/main/java/com/webrtc/boyj/api/BoyjRTC.java
+++ b/app/src/main/java/com/webrtc/boyj/api/BoyjRTC.java
@@ -21,7 +21,7 @@ public class BoyjRTC {
     public BoyjRTC() {
     }
 
-    public void pushReceived(@NonNull final FCMPayload fcmPayload) {
+    public void onPushReceived(@NonNull final FCMPayload fcmPayload) {
 
         //노크 이벤트를 수신하면 , 링액티비티를 실행시킨다. 이 서브스크립션은 1번만 실행된후 해제되므로 따로 리소스 해제를 시킬 필요가 없다.
         signalingClient.getKnockSubject().take(1).subscribe(o -> {

--- a/app/src/main/java/com/webrtc/boyj/api/BoyjRTC.java
+++ b/app/src/main/java/com/webrtc/boyj/api/BoyjRTC.java
@@ -1,14 +1,12 @@
 package com.webrtc.boyj.api;
 
-import android.content.Intent;
 import android.support.annotation.NonNull;
 
 import com.webrtc.boyj.api.signalling.SignalingClient;
 import com.webrtc.boyj.api.signalling.payload.AwakenPayload;
 import com.webrtc.boyj.api.signalling.payload.DialPayload;
-import com.webrtc.boyj.api.signalling.payload.FCMPayload;
-import com.webrtc.boyj.presentation.ringing.RingingActivity;
-import com.webrtc.boyj.utils.App;
+
+import io.reactivex.subjects.CompletableSubject;
 
 public class BoyjRTC {
     @NonNull
@@ -21,36 +19,30 @@ public class BoyjRTC {
     public BoyjRTC() {
     }
 
-    public void onPushReceived(@NonNull final FCMPayload fcmPayload) {
-
-        //노크 이벤트를 수신하면 , 링액티비티를 실행시킨다. 이 서브스크립션은 1번만 실행된후 해제되므로 따로 리소스 해제를 시킬 필요가 없다.
-        signalingClient.getKnockSubject().take(1).subscribe(o -> {
-            Intent intent = RingingActivity.getLaunchIntent(App.getContext(), fcmPayload);
-            App.getContext().startActivity(intent);
-        });
-
-
-        final String room = fcmPayload.getRoom();
-        final AwakenPayload awakenPayload = new AwakenPayload.Builder(room).build();
-        signalingClient.emitAwaken(awakenPayload);
-
-    }
-
     //앱 유저로 부터 온 이벤트 처리
-    public void callAction(@NonNull final DialPayload dialPayload) {
+    public void dial(@NonNull final DialPayload dialPayload) {
         signalingClient.emitDial(dialPayload);
     }
 
-    public void acceptAction() {
+    public void accept() {
         signalingClient.emitAccept();
     }
 
-    public void rejectAction() {
+    public void reject() {
         signalingClient.emitReject();
     }
 
-    public void hangupAction() {
+    public void hangUp() {
         signalingClient.emitBye();
         signalingClient.disconnect();
+    }
+
+    public void awaken(@NonNull final AwakenPayload payload) {
+        signalingClient.emitAwaken(payload);
+    }
+
+    @NonNull
+    public CompletableSubject knock() {
+        return signalingClient.getKnockSubject();
     }
 }

--- a/app/src/main/java/com/webrtc/boyj/api/BoyjRTC.java
+++ b/app/src/main/java/com/webrtc/boyj/api/BoyjRTC.java
@@ -1,0 +1,48 @@
+package com.webrtc.boyj.api;
+
+import android.support.annotation.NonNull;
+
+import com.webrtc.boyj.api.signalling.SignalingClient;
+import com.webrtc.boyj.api.signalling.payload.AwakenPayload;
+import com.webrtc.boyj.api.signalling.payload.DialPayload;
+import com.webrtc.boyj.api.signalling.payload.FCMPayload;
+import com.webrtc.boyj.data.model.User;
+
+public class BoyjRTC {
+    @NonNull
+    private final static SignalingClient signalingClient;
+
+
+    static {
+        signalingClient = new SignalingClient();
+    }
+
+    public BoyjRTC() {
+    }
+
+    public void pushReceived(@NonNull final FCMPayload fcmPayload) {
+        final String room = fcmPayload.getRoom();
+
+        final AwakenPayload awakenPayload = new AwakenPayload.Builder(room).build();
+        signalingClient.emitAwaken(awakenPayload);
+    }
+
+
+    //앱 유저로 부터 온 이벤트 처리
+    public void callActionTo(@NonNull final User user) {
+        final DialPayload dialPayload = new DialPayload.Builder(user.getDeviceToken()).build();
+        signalingClient.emitDial(dialPayload);
+    }
+
+    public void acceptAction() {
+        signalingClient.emitAccept();
+    }
+
+    public void rejectAction() {
+        signalingClient.emitReject();
+    }
+
+    public void hangupAction() {
+        signalingClient.emitBye();
+    }
+}

--- a/app/src/main/java/com/webrtc/boyj/api/BoyjRTC.java
+++ b/app/src/main/java/com/webrtc/boyj/api/BoyjRTC.java
@@ -1,17 +1,18 @@
 package com.webrtc.boyj.api;
 
+import android.content.Intent;
 import android.support.annotation.NonNull;
 
 import com.webrtc.boyj.api.signalling.SignalingClient;
 import com.webrtc.boyj.api.signalling.payload.AwakenPayload;
 import com.webrtc.boyj.api.signalling.payload.DialPayload;
 import com.webrtc.boyj.api.signalling.payload.FCMPayload;
-import com.webrtc.boyj.data.model.User;
+import com.webrtc.boyj.presentation.ringing.RingingActivity;
+import com.webrtc.boyj.utils.App;
 
 public class BoyjRTC {
     @NonNull
     private final static SignalingClient signalingClient;
-
 
     static {
         signalingClient = new SignalingClient();
@@ -21,16 +22,22 @@ public class BoyjRTC {
     }
 
     public void pushReceived(@NonNull final FCMPayload fcmPayload) {
-        final String room = fcmPayload.getRoom();
 
+        //노크 이벤트를 수신하면 , 링액티비티를 실행시킨다. 이 서브스크립션은 1번만 실행된후 해제되므로 따로 리소스 해제를 시킬 필요가 없다.
+        signalingClient.getKnockSubject().take(1).subscribe(o -> {
+            Intent intent = RingingActivity.getLaunchIntent(App.getContext(), fcmPayload);
+            App.getContext().startActivity(intent);
+        });
+
+
+        final String room = fcmPayload.getRoom();
         final AwakenPayload awakenPayload = new AwakenPayload.Builder(room).build();
         signalingClient.emitAwaken(awakenPayload);
+
     }
 
-
     //앱 유저로 부터 온 이벤트 처리
-    public void callActionTo(@NonNull final User user) {
-        final DialPayload dialPayload = new DialPayload.Builder(user.getDeviceToken()).build();
+    public void callAction(@NonNull final DialPayload dialPayload) {
         signalingClient.emitDial(dialPayload);
     }
 
@@ -44,5 +51,6 @@ public class BoyjRTC {
 
     public void hangupAction() {
         signalingClient.emitBye();
+        signalingClient.disconnect();
     }
 }

--- a/app/src/main/java/com/webrtc/boyj/api/firebase/MyFirebaseMessagingService.java
+++ b/app/src/main/java/com/webrtc/boyj/api/firebase/MyFirebaseMessagingService.java
@@ -1,5 +1,6 @@
 package com.webrtc.boyj.api.firebase;
 
+import android.content.Intent;
 import android.content.SharedPreferences;
 import android.preference.PreferenceManager;
 import android.support.annotation.NonNull;
@@ -7,8 +8,11 @@ import android.support.annotation.NonNull;
 import com.google.firebase.messaging.FirebaseMessagingService;
 import com.google.firebase.messaging.RemoteMessage;
 import com.webrtc.boyj.api.BoyjRTC;
+import com.webrtc.boyj.api.signalling.payload.AwakenPayload;
 import com.webrtc.boyj.api.signalling.payload.FCMPayload;
 import com.webrtc.boyj.data.repository.UserRepositoryImpl;
+import com.webrtc.boyj.presentation.ringing.RingingActivity;
+import com.webrtc.boyj.utils.App;
 import com.webrtc.boyj.utils.Logger;
 
 public class MyFirebaseMessagingService extends FirebaseMessagingService {
@@ -24,8 +28,16 @@ public class MyFirebaseMessagingService extends FirebaseMessagingService {
         final FCMPayload payload = new FCMPayload(remoteMessage);
 
         final BoyjRTC boyjRTC = new BoyjRTC();
-        boyjRTC.onPushReceived(payload);
+        boyjRTC.knock().subscribe(() -> {
+            final Intent intent = RingingActivity.getLaunchIntent(getApplicationContext(), payload);
+            startActivity(intent);
+        });
+
+        final String room = payload.getRoom();
+        final AwakenPayload awakenPayload = new AwakenPayload.Builder(room).build();
+        boyjRTC.awaken(awakenPayload);
     }
+
 
     @Override
     public void onNewToken(@NonNull final String token) {

--- a/app/src/main/java/com/webrtc/boyj/api/firebase/MyFirebaseMessagingService.java
+++ b/app/src/main/java/com/webrtc/boyj/api/firebase/MyFirebaseMessagingService.java
@@ -6,9 +6,7 @@ import android.support.annotation.NonNull;
 
 import com.google.firebase.messaging.FirebaseMessagingService;
 import com.google.firebase.messaging.RemoteMessage;
-import com.webrtc.boyj.api.signalling.SignalingClient;
-import com.webrtc.boyj.api.signalling.SignalingClientFactory;
-import com.webrtc.boyj.api.signalling.payload.AwakenPayload;
+import com.webrtc.boyj.api.BoyjRTC;
 import com.webrtc.boyj.api.signalling.payload.FCMPayload;
 import com.webrtc.boyj.data.repository.UserRepositoryImpl;
 import com.webrtc.boyj.utils.Logger;
@@ -24,7 +22,9 @@ public class MyFirebaseMessagingService extends FirebaseMessagingService {
         Logger.d("FCM received");
 
         final FCMPayload payload = new FCMPayload(remoteMessage);
-        handleNow(payload);
+
+        final BoyjRTC boyjRTC = new BoyjRTC();
+        boyjRTC.pushReceived(payload);
     }
 
     @Override
@@ -36,11 +36,4 @@ public class MyFirebaseMessagingService extends FirebaseMessagingService {
                 .apply();
     }
 
-    public void handleNow(@NonNull final FCMPayload payload) {
-        final String room = payload.getRoom();
-        final SignalingClient signalingClient = SignalingClientFactory.getSignalingClient();
-        final AwakenPayload awakenPayload = new AwakenPayload.Builder(room).build();
-
-        signalingClient.emitAwaken(awakenPayload);
-    }
 }

--- a/app/src/main/java/com/webrtc/boyj/api/firebase/MyFirebaseMessagingService.java
+++ b/app/src/main/java/com/webrtc/boyj/api/firebase/MyFirebaseMessagingService.java
@@ -24,7 +24,7 @@ public class MyFirebaseMessagingService extends FirebaseMessagingService {
         final FCMPayload payload = new FCMPayload(remoteMessage);
 
         final BoyjRTC boyjRTC = new BoyjRTC();
-        boyjRTC.pushReceived(payload);
+        boyjRTC.onPushReceived(payload);
     }
 
     @Override

--- a/app/src/main/java/com/webrtc/boyj/api/signalling/SignalingClient.java
+++ b/app/src/main/java/com/webrtc/boyj/api/signalling/SignalingClient.java
@@ -8,13 +8,20 @@ import com.webrtc.boyj.api.signalling.payload.DialPayload;
 import com.webrtc.boyj.api.signalling.payload.IceCandidatePayload;
 import com.webrtc.boyj.api.signalling.payload.SdpPayload;
 
+import io.reactivex.subjects.PublishSubject;
+
 public class SignalingClient {
 
     @NonNull
-    private static final SocketIOClient socketIOClient;
+    private static final SocketIOClient socketIOClient = new SocketIOClient();
+    private static final PublishSubject knockSubject = PublishSubject.create();
 
     static {
-        socketIOClient = new SocketIOClient();
+        socketIOClient.on(SignalingEventString.EVENT_KNOCK, args -> knockSubject.onNext("knock"));
+    }
+
+    public PublishSubject getKnockSubject() {
+        return knockSubject;
     }
 
     public SignalingClient() {
@@ -49,7 +56,7 @@ public class SignalingClient {
         socketIOClient.emit(SignalingEventString.EVENT_BYE);
     }
 
-    public void disconnect(){
+    public void disconnect() {
         socketIOClient.disconnect();
     }
 }

--- a/app/src/main/java/com/webrtc/boyj/api/signalling/SignalingClient.java
+++ b/app/src/main/java/com/webrtc/boyj/api/signalling/SignalingClient.java
@@ -8,23 +8,25 @@ import com.webrtc.boyj.api.signalling.payload.DialPayload;
 import com.webrtc.boyj.api.signalling.payload.IceCandidatePayload;
 import com.webrtc.boyj.api.signalling.payload.SdpPayload;
 
+import org.webrtc.IceCandidate;
+import org.webrtc.SessionDescription;
+
+import io.reactivex.subjects.CompletableSubject;
 import io.reactivex.subjects.PublishSubject;
 
 public class SignalingClient {
 
     @NonNull
-    private static final SocketIOClient socketIOClient = new SocketIOClient();
-    private static final PublishSubject knockSubject = PublishSubject.create();
+    private static final SocketIOClient socketIOClient;
 
     static {
-        socketIOClient.on(SignalingEventString.EVENT_KNOCK, args -> knockSubject.onNext("knock"));
+        socketIOClient = new SocketIOClient();
     }
 
-    public PublishSubject getKnockSubject() {
-        return knockSubject;
-    }
+    private CompletableSubject knockSubject = CompletableSubject.create();
 
     public SignalingClient() {
+        socketIOClient.on(SignalingEventString.EVENT_KNOCK, args -> knockSubject.onComplete());
         socketIOClient.connect();
     }
 
@@ -59,4 +61,10 @@ public class SignalingClient {
     public void disconnect() {
         socketIOClient.disconnect();
     }
+
+    public CompletableSubject getKnockSubject() {
+        return knockSubject;
+    }
+
+
 }

--- a/app/src/main/java/com/webrtc/boyj/api/signalling/SocketIOClient.java
+++ b/app/src/main/java/com/webrtc/boyj/api/signalling/SocketIOClient.java
@@ -10,6 +10,7 @@ import java.net.URISyntaxException;
 
 import io.socket.client.IO;
 import io.socket.client.Socket;
+import io.socket.emitter.Emitter;
 
 public class SocketIOClient {
 
@@ -44,5 +45,9 @@ public class SocketIOClient {
 
     public void emit(@NonNull final String event, @Nullable final Object... args) {
         socket.emit(event, args);
+    }
+
+    public Emitter on(String event, Emitter.Listener fn) {
+        return socket.on(event, fn);
     }
 }

--- a/app/src/main/java/com/webrtc/boyj/api/signalling/payload/Payload.java
+++ b/app/src/main/java/com/webrtc/boyj/api/signalling/payload/Payload.java
@@ -4,7 +4,9 @@ import android.support.annotation.NonNull;
 
 import com.google.gson.Gson;
 
-public abstract class Payload {
+import java.io.Serializable;
+
+public abstract class Payload implements Serializable {
 
     @NonNull
     public String toJson() {

--- a/app/src/main/java/com/webrtc/boyj/presentation/call/CallViewModel.java
+++ b/app/src/main/java/com/webrtc/boyj/presentation/call/CallViewModel.java
@@ -3,11 +3,8 @@ package com.webrtc.boyj.presentation.call;
 import android.databinding.ObservableBoolean;
 import android.databinding.ObservableInt;
 import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
 
 import com.webrtc.boyj.api.BoyjRTC;
-import com.webrtc.boyj.api.signalling.SignalingClient;
-import com.webrtc.boyj.api.signalling.SocketConnectionFailedException;
 import com.webrtc.boyj.api.signalling.payload.DialPayload;
 import com.webrtc.boyj.data.model.User;
 import com.webrtc.boyj.presentation.BaseViewModel;
@@ -43,10 +40,11 @@ public class CallViewModel extends BaseViewModel {
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe(callTime::set));
 
-        boyjRTC.callActionTo(otherUser);
-
+        final DialPayload dialPayload = new DialPayload.Builder(otherUser.getDeviceToken()).build();
+        boyjRTC.callAction(dialPayload);
     }
-    public void hangUp(){
+
+    public void hangUp() {
         boyjRTC.hangupAction();
     }
 

--- a/app/src/main/java/com/webrtc/boyj/presentation/call/CallViewModel.java
+++ b/app/src/main/java/com/webrtc/boyj/presentation/call/CallViewModel.java
@@ -32,6 +32,13 @@ public class CallViewModel extends BaseViewModel {
         boyjRTC = new BoyjRTC();
     }
 
+    //전화 거는 요청
+    public void dial() {
+        DialPayload dialPayload = new DialPayload.Builder(otherUser.getDeviceToken()).build();
+        boyjRTC.dial(dialPayload);
+    }
+
+    //전화 연결 되었을때 작업
     public void call() {
         isCalling.set(true);
 
@@ -39,13 +46,10 @@ public class CallViewModel extends BaseViewModel {
                 .map(Long::intValue)
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe(callTime::set));
-
-        final DialPayload dialPayload = new DialPayload.Builder(otherUser.getDeviceToken()).build();
-        boyjRTC.callAction(dialPayload);
     }
 
     public void hangUp() {
-        boyjRTC.hangupAction();
+        boyjRTC.hangUp();
     }
 
     @NonNull

--- a/app/src/main/java/com/webrtc/boyj/presentation/call/CallViewModel.java
+++ b/app/src/main/java/com/webrtc/boyj/presentation/call/CallViewModel.java
@@ -5,13 +5,12 @@ import android.databinding.ObservableInt;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 
+import com.webrtc.boyj.api.BoyjRTC;
 import com.webrtc.boyj.api.signalling.SignalingClient;
-import com.webrtc.boyj.api.signalling.SignalingClientFactory;
 import com.webrtc.boyj.api.signalling.SocketConnectionFailedException;
 import com.webrtc.boyj.api.signalling.payload.DialPayload;
 import com.webrtc.boyj.data.model.User;
 import com.webrtc.boyj.presentation.BaseViewModel;
-import com.webrtc.boyj.presentation.main.MainActivity;
 
 import java.util.concurrent.TimeUnit;
 
@@ -25,19 +24,15 @@ public class CallViewModel extends BaseViewModel {
     private final ObservableBoolean isCalling = new ObservableBoolean(false);
     @NonNull
     private final ObservableInt callTime = new ObservableInt(0);
-    @Nullable
-    private SignalingClient signalingClient;
+
+    @NonNull
+    private final BoyjRTC boyjRTC;
 
     public CallViewModel(@NonNull User otherUser) {
 
         this.otherUser = otherUser;
-        try {
-            signalingClient = SignalingClientFactory.getSignalingClient();
-        } catch (SocketConnectionFailedException e) {
-            //TODO 시그널링 서버 접속 에러를 사용자에게 알린후 재시도 유도
-            e.printStackTrace();
-            throw new RuntimeException();
-        }
+
+        boyjRTC = new BoyjRTC();
     }
 
     public void call() {
@@ -48,11 +43,11 @@ public class CallViewModel extends BaseViewModel {
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe(callTime::set));
 
-        final DialPayload dialPayload = new DialPayload.Builder(otherUser.getDeviceToken()).build();
-        signalingClient.emitDial(dialPayload);
+        boyjRTC.callActionTo(otherUser);
+
     }
     public void hangUp(){
-        signalingClient.emitBye();
+        boyjRTC.hangupAction();
     }
 
     @NonNull

--- a/app/src/main/java/com/webrtc/boyj/presentation/ringing/RingingActivity.java
+++ b/app/src/main/java/com/webrtc/boyj/presentation/ringing/RingingActivity.java
@@ -1,15 +1,21 @@
 package com.webrtc.boyj.presentation.ringing;
 
+import android.content.Context;
+import android.content.Intent;
 import android.os.Bundle;
+import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 
 import com.webrtc.boyj.R;
+import com.webrtc.boyj.api.signalling.payload.FCMPayload;
 import com.webrtc.boyj.data.model.User;
 import com.webrtc.boyj.databinding.ActivityRingingBinding;
 import com.webrtc.boyj.presentation.BaseActivity;
 import com.webrtc.boyj.presentation.call.CallActivity;
 
 public class RingingActivity extends BaseActivity<ActivityRingingBinding> {
+
+    private static final String EXTRA_FCM_PAYLOAD = "EXTRA_FCM_PAYLOAD";
 
     @Override
     protected void onCreate(@Nullable Bundle savedInstanceState) {
@@ -33,6 +39,14 @@ public class RingingActivity extends BaseActivity<ActivityRingingBinding> {
         overridePendingTransition(R.anim.slide_from_right, R.anim.slide_to_left);
         finish();
     }
+
+
+    public static Intent getLaunchIntent(@NonNull final Context context,
+                                         @NonNull final FCMPayload payload) {
+        return getLaunchIntent(context, RingingActivity.class)
+                .putExtra(EXTRA_FCM_PAYLOAD, payload);
+    }
+
 
     @Override
     protected int getLayoutId() {

--- a/app/src/main/java/com/webrtc/boyj/presentation/ringing/RingingViewModel.java
+++ b/app/src/main/java/com/webrtc/boyj/presentation/ringing/RingingViewModel.java
@@ -1,15 +1,24 @@
 package com.webrtc.boyj.presentation.ringing;
 
+import android.support.annotation.NonNull;
+
+import com.webrtc.boyj.api.BoyjRTC;
 import com.webrtc.boyj.api.signalling.SignalingClient;
-import com.webrtc.boyj.api.signalling.SignalingClientFactory;
 
 public class RingingViewModel {
-    public void acceptAction(){
-        SignalingClient signalingClient = SignalingClientFactory.getSignalingClient();
-        signalingClient.emitAccept();
+
+    @NonNull
+    private final BoyjRTC boyjRTC;
+
+    public RingingViewModel() {
+        boyjRTC = new BoyjRTC();
     }
-    public void rejectAction(){
-        SignalingClient signalingClient = SignalingClientFactory.getSignalingClient();
-        signalingClient.emitReject();
+
+    public void acceptAction() {
+        boyjRTC.acceptAction();
+    }
+
+    public void rejectAction() {
+        boyjRTC.rejectAction();
     }
 }

--- a/app/src/main/java/com/webrtc/boyj/presentation/ringing/RingingViewModel.java
+++ b/app/src/main/java/com/webrtc/boyj/presentation/ringing/RingingViewModel.java
@@ -14,11 +14,11 @@ public class RingingViewModel {
         boyjRTC = new BoyjRTC();
     }
 
-    public void acceptAction() {
-        boyjRTC.acceptAction();
+    public void accept() {
+        boyjRTC.accept();
     }
 
-    public void rejectAction() {
-        boyjRTC.rejectAction();
+    public void reject() {
+        boyjRTC.reject();
     }
 }


### PR DESCRIPTION
 Issue  #68 

### 개요
* 기존의 앱사용자의 액션  , 서버에서 오는 이벤트 , 피어에서 오는 이벤트에 대한 처리가 
여러곳에 산재되어 있어 관리하기 힘들다.
따라서 한곳에서 처리하는 클래스가 필요하다

### 구현 사항
 - 앱 사용자의 dial, accept , reject , hangup 액션에 대한 로직 처리
 - fcm 을 수신했을때의 로직 처리

### 발생 이슈
@tbtzpdlql 
 - dial, accept , reject , hangup 액션에 대한 이벤트 처리를 하였으므로 ,이에 대한 뷰 처리 부탁드립니다. 








